### PR TITLE
Allow passing limit param to Vector Search

### DIFF
--- a/onyxgenai/embed.py
+++ b/onyxgenai/embed.py
@@ -45,12 +45,12 @@ class EmbeddingClient:
             print("Failed to get embedding:", response.status_code, response.text)
             return None
 
-    def _onyx_vector_search(self, query: str, collection_name: str):
+    def _onyx_vector_search(self, query: str, collection_name: str, limit: int):
         url = f"{self.svc_url}/vector-store/search"
         payload = {
             "query_vector": query,
             "collection_name": collection_name,
-            "kwargs": {"limit": 3},
+            "kwargs": {"limit": limit},
         }
 
         response = requests.post(url, json=payload)
@@ -183,16 +183,17 @@ class EmbeddingClient:
 
         return results
 
-    def vector_search(self, query, collection_name):
+    def vector_search(self, query, collection_name, limit=3):
         """
         Search for vectors in the collection
         Args:
             query (str): The query vector
             collection_name (str): The name of the collection
+            limit (int): The number of results to return (default 3)
         Returns:
             list: The vector search results
         """
-        return self._onyx_vector_search(query, collection_name)
+        return self._onyx_vector_search(query, collection_name, limit)
 
     def get_collections(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "onyxgenai"
-version = "1.0.3"
+version = "1.0.4"
 description = "Python SDK for interacting with Onyx Generative AI Services"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -55,6 +55,22 @@ def test_onyx_vector_search(mock_post):
     assert result == mock_response["results"]
 
 
+@patch("requests.post")
+def test_onyx_vector_search_with_limit(mock_post):
+    svc_url = "http://localhost:8000"
+    client = EmbeddingClient(svc_url)
+    mock_response = {"results": ["result1", "result2", "result3"]}
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = mock_response
+
+    query = "sample query"
+    collection_name = "test_collection"
+    limit = 10
+    result = client.vector_search(query, collection_name, 10)
+
+    assert result == mock_response["results"]
+
+
 @patch("requests.get")
 def test_onyx_get_collections(mock_get):
     svc_url = "http://localhost:8000"

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -66,7 +66,7 @@ def test_onyx_vector_search_with_limit(mock_post):
     query = "sample query"
     collection_name = "test_collection"
     limit = 10
-    result = client.vector_search(query, collection_name, 10)
+    result = client.vector_search(query, collection_name, limit)
 
     assert result == mock_response["results"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 
- Updated vector search method to allow limit param, default to 3
- Add test
- Update to next patch version

## Related Issue

N/A

## Motivation and Context

- Support expanded search results

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):
N/A